### PR TITLE
Add "," (comma) to the allowed chars list of the "addlinkexplanation" command.

### DIFF
--- a/shadowsden.py
+++ b/shadowsden.py
@@ -190,8 +190,8 @@ def command_addlinkexplanation(cmd, bot, args, msg, event):
     removelinkexplanation((w1, w2))  # remove any older explanations
     if not links_contain((w1, w2)):
         return "That link does not exist."
-    if re.compile(r"[^a-zA-Z0-9_%*/:.#()\[\]?&=-]").search(args[2]):
-        return "Sorry, your explanation can only contain the chars `a-zA-Z_*%/:.#()[]-`."
+    if re.compile(r"[^a-zA-Z0-9_%*/:.#()\[\]?&=-,]").search(args[2]):
+        return "Sorry, your explanation can only contain the chars `a-zA-Z_*%/:.#()[]=-,`."
     Data.link_explanations.append(((w1, w2), args[2]))
     SaveIO.save(Data.link_explanations, save_subdir, "linkExplanations")
     return "Explanation added."


### PR DESCRIPTION
Hello. So I were adding the explanation to the link "lol => lo" with the following:  
> While_LOL_is_Laughing_Out_Loudly,_LO_is_just_Laughing_Out.`

And the bot said:  
> Sorry, your explanation can only contain the chars <code>a-zA-Z_*%&#47;:.#()[]-</code>.

I want to fix it, I think we should be able to add the comma into explanation, aren't we?